### PR TITLE
feat: added token aware chunking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
       matrix:
         python-version: ['3.11', '3.12']
         django-version: ['4.2', '5.2']
+        include:
+          - django-version: '4.2'
+            wagtail-version: 'wagtail>=6.0,<7'
+          - django-version: '5.2'
+            wagtail-version: 'wagtail>=7.0'
 
     steps:
     - uses: actions/checkout@v4
@@ -29,7 +34,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install "Django==${{ matrix.django-version }}.*"
-        pip install wagtail
+        pip install "${{ matrix.wagtail-version }}"
         pip install -e ".[test,local]"
 
     - name: Run tests

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A plug-and-play RAG (Retrieval-Augmented Generation) chatbot for Wagtail CMS. Dr
 
 - **Universal**: works with any Wagtail page model; auto-discovers content fields
 - **Per-field chunking**: each field (body, introduction, …) is chunked independently with section metadata, so the LLM always knows where a chunk came from
+- **Token-aware chunking**: paragraph-first splitting with token-aware sizing (default `chunk_size=800`, `chunk_overlap=128`)
 - **Hybrid retrieval**: vector similarity search + optional Wagtail full-text search
 - **Multiple vector stores**: FAISS (default), ChromaDB, pgvector (PostgreSQL)
 - **Multiple embedding providers**: HuggingFace, Sentence Transformers, OpenAI
@@ -241,8 +242,8 @@ WAGTAIL_RAG = {
 
     # ── Indexing ──────────────────────────────────────────────────────────
     "indexing": {
-        "chunk_size":      1500,   # characters per chunk
-        "chunk_overlap":   100,    # overlap between consecutive chunks
+        "chunk_size":      800,    # target tokens per chunk
+        "chunk_overlap":   128,    # token overlap between consecutive chunks
         "batch_size":      100,    # pages embedded per batch
         "skip_if_indexed": True,   # skip pages that haven't changed since last index
         "prune_deleted":   True,   # remove chunks for pages deleted from Wagtail
@@ -257,7 +258,7 @@ WAGTAIL_RAG = {
 
     # ── Search / retrieval ────────────────────────────────────────────────
     "search": {
-        "k":                   8,     # chunks retrieved per query
+        "k":                   10,    # chunks retrieved per query
         "max_sources":         3,     # unique pages shown as sources in the response
         "use_hybrid":          True,  # combine vector search + Wagtail full-text search
         "use_query_expansion": False, # generate multiple query variants via MultiQueryRetriever
@@ -288,11 +289,11 @@ WAGTAIL_RAG = {
 | `vector_store` | `collection` | `"wagtail_rag"` | Collection / index name |
 | `vector_store` | `connection_string` | derived from `DATABASES` | pgvector only |
 | `indexing` | `models` | `{}` | Models and fields to index |
-| `indexing` | `chunk_size` | `1500` | Characters per chunk |
-| `indexing` | `chunk_overlap` | `100` | Overlap between chunks |
+| `indexing` | `chunk_size` | `800` | Target tokens per chunk |
+| `indexing` | `chunk_overlap` | `128` | Token overlap between chunks |
 | `indexing` | `skip_if_indexed` | `True` | Skip unchanged pages |
 | `indexing` | `prune_deleted` | `True` | Remove stale chunks |
-| `search` | `k` | `8` | Chunks retrieved per query |
+| `search` | `k` | `10` | Chunks retrieved per query |
 | `search` | `max_sources` | `3` | Source pages shown in response |
 | `search` | `use_hybrid` | `True` | Vector + Wagtail full-text search |
 | `search` | `use_query_expansion` | `True` | MultiQueryRetriever query expansion |
@@ -411,7 +412,7 @@ chatbot = get_chatbot(llm_provider="openai", model_name="gpt-4o")
 
 ## How It Works
 
-1. **Indexing** (`rag index`): discovers live Wagtail pages → extracts each field independently → chunks with paragraph preservation → prepends `Page: / Section:` header to every chunk → upserts into vector store with deterministic IDs (`{page_id}_{field}_{chunk_index}`). Stale chunks are removed before re-indexing.
+1. **Indexing** (`rag index`): discovers live Wagtail pages → auto-discovers text-bearing fields (including `*_search_text`) → creates one canonical full-page blob + labeled per-field chunks with paragraph-first token-aware splitting → prepends `Page: / Section:` header to every chunk → upserts into vector store with deterministic IDs (`{page_id}_{field}_{chunk_index}`). Stale chunks are removed before re-indexing.
 
 2. **Querying** (`rag chat` / API): embeds the question → vector similarity search → optional Wagtail full-text search → deduplicate & title-boost → pass top-k chunks as context to LLM → return answer + sources.
 

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     install_requires=[
         "django>=3.2",
         "wagtail>=4.0",
-        "langchain>=0.1.0,<0.2.0",
+        "langchain>=0.3.0",
         "langchain-community>=0.3.27",  # Security: Fix XXE, SSRF, and pickle deserialization vulnerabilities
         "langchain-text-splitters>=0.3.9",  # Security: Fix XXE vulnerability via unsafe XSLT parsing
         "beautifulsoup4>=4.12.0",

--- a/wagtail_rag/chatbot.py
+++ b/wagtail_rag/chatbot.py
@@ -54,6 +54,7 @@ class RAGChatBot:
         metadata_filter=None,
         llm_provider=None,
         llm_kwargs=None,
+        use_token_aware_chunking=None,
     ):
         self.collection_name = collection_name or conf.vector_store.collection
         self.persist_directory = persist_directory or conf.vector_store.path
@@ -61,6 +62,11 @@ class RAGChatBot:
         self.model_name = model_name or conf.llm.model
         self.metadata_filter = metadata_filter or {}
         self.k_value = conf.search.k
+
+        if use_token_aware_chunking is not None:
+            self.use_token_aware_chunking = bool(use_token_aware_chunking)
+        else:
+            self.use_token_aware_chunking = conf.indexing.use_token_aware_chunking
 
         embedding_provider = conf.embedding.provider
         embedding_model = conf.embedding.model
@@ -237,6 +243,7 @@ def get_chatbot(
     metadata_filter=None,
     llm_provider=None,
     llm_kwargs=None,
+    use_token_aware_chunking=None,
 ) -> RAGChatBot:
     """Convenience factory for RAGChatBot. All args default to settings."""
     return RAGChatBot(
@@ -245,4 +252,5 @@ def get_chatbot(
         metadata_filter=metadata_filter,
         llm_provider=llm_provider,
         llm_kwargs=llm_kwargs,
+        use_token_aware_chunking=use_token_aware_chunking,
     )

--- a/wagtail_rag/conf.py
+++ b/wagtail_rag/conf.py
@@ -38,7 +38,7 @@ deployments continue to work without changes.
             },
         },
         "search": {
-            "k":                  8,    # chunks retrieved per query
+            "k":                  10,   # chunks retrieved per query
             "max_sources":        3,    # unique pages shown as sources
             "use_hybrid":         True, # combine vector + Wagtail full-text search
             "use_query_expansion": True, # MultiQueryRetriever

--- a/wagtail_rag/conf.py
+++ b/wagtail_rag/conf.py
@@ -24,11 +24,12 @@ deployments continue to work without changes.
             # "connection_string": "postgresql+psycopg2://..."  # pgvector only
         },
         "indexing": {
-            "chunk_size":      1500,
-            "chunk_overlap":   100,
+            "chunk_size":      800,
+            "chunk_overlap":   128,
             "batch_size":      100,
             "skip_if_indexed": True,
             "prune_deleted":   True,
+            "use_token_aware_chunking": False,  # True → token-aware paragraph chunker; False → RecursiveCharacterTextSplitter
             "models": {
                 # ["f1", "f2"] → use exactly these fields
                 # "*"          → use Wagtail search_fields automatically
@@ -201,12 +202,12 @@ class _IndexingConf:
 
     @property
     def chunk_size(self) -> int:
-        return _get_int(self._group(), "chunk_size", "WAGTAIL_RAG_CHUNK_SIZE", 1500)
+        return _get_int(self._group(), "chunk_size", "WAGTAIL_RAG_CHUNK_SIZE", 800)
 
     @property
     def chunk_overlap(self) -> int:
         return _get_int(
-            self._group(), "chunk_overlap", "WAGTAIL_RAG_CHUNK_OVERLAP", 100
+            self._group(), "chunk_overlap", "WAGTAIL_RAG_CHUNK_OVERLAP", 128
         )
 
     @property
@@ -227,6 +228,15 @@ class _IndexingConf:
             self._group(), "prune_deleted", "WAGTAIL_RAG_PRUNE_DELETED", True
         )
 
+    @property
+    def use_token_aware_chunking(self) -> bool:
+        return _get_bool(
+            self._group(),
+            "use_token_aware_chunking",
+            "WAGTAIL_RAG_USE_TOKEN_AWARE_CHUNKING",
+            False,
+        )
+
 
 class _SearchConf:
     def _group(self) -> dict:
@@ -234,7 +244,7 @@ class _SearchConf:
 
     @property
     def k(self) -> int:
-        return _get_int(self._group(), "k", "WAGTAIL_RAG_RETRIEVE_K", 8)
+        return _get_int(self._group(), "k", "WAGTAIL_RAG_RETRIEVE_K", 10)
 
     @property
     def max_sources(self) -> int:

--- a/wagtail_rag/content_extraction/api_fields_extractor.py
+++ b/wagtail_rag/content_extraction/api_fields_extractor.py
@@ -28,9 +28,6 @@ except Exception:
 
 logger = logging.getLogger(__name__)
 
-# Defaults read from conf so settings drive behavior
-DEFAULT_CHUNK_SIZE = conf.indexing.chunk_size
-DEFAULT_CHUNK_OVERLAP = conf.indexing.chunk_overlap
 MIN_FIELD_LENGTH = 10
 
 # Fields on every Wagtail page that carry no user content.
@@ -80,8 +77,8 @@ class WagtailAPIExtractor:
         chunk_overlap: Optional[int] = None,
         use_token_aware_chunking: Optional[bool] = None,
     ):
-        self.chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
-        self.chunk_overlap = chunk_overlap or DEFAULT_CHUNK_OVERLAP
+        self.chunk_size = chunk_size or conf.indexing.chunk_size
+        self.chunk_overlap = chunk_overlap or conf.indexing.chunk_overlap
 
         if use_token_aware_chunking is not None:
             self._use_token_aware = bool(use_token_aware_chunking)
@@ -266,16 +263,27 @@ class WagtailAPIExtractor:
                 chunks = self.text_splitter.split_text(block_text)
 
             for i, chunk in enumerate(chunks):
+                chunk_meta = {
+                    **block_meta,
+                    "chunk_index": chunk_index,
+                    "block_chunk_index": i,
+                    "total_block_chunks": len(chunks),
+                    "content_length": len(chunk),
+                }
+                if self._use_token_aware:
+                    try:
+                        chunk_meta["token_count"] = len(
+                            self.tokenizer.encode(chunk, add_special_tokens=False)
+                        )
+                    except Exception:
+                        chunk_meta["token_count"] = None
+                    chunk_meta["chunk_kind"] = "streamfield_block"
+                    chunk_meta["indexer_version"] = "token-aware-v2-20260508"
+
                 documents.append(
                     Document(
                         page_content=f"{header}{chunk}",
-                        metadata={
-                            **block_meta,
-                            "chunk_index": chunk_index,
-                            "block_chunk_index": i,
-                            "total_block_chunks": len(chunks),
-                            "content_length": len(chunk),
-                        },
+                        metadata=chunk_meta,
                     )
                 )
                 chunk_index += 1

--- a/wagtail_rag/content_extraction/api_fields_extractor.py
+++ b/wagtail_rag/content_extraction/api_fields_extractor.py
@@ -1,15 +1,3 @@
-"""
-Converts Wagtail pages into LangChain Documents for RAG indexing.
-
-Field resolution per page:
-  1. Explicit list in settings  → ["introduction", "body", "address"]
-  2. "*" in settings            → Wagtail search_fields (text-only, curated)
-
-Each field is chunked independently:
-  - StreamField  → per-block chunking (preserves Wagtail structure)
-  - Other fields → RecursiveCharacterTextSplitter
-"""
-
 import logging
 import re
 from typing import List, Optional
@@ -28,10 +16,18 @@ try:
 except ImportError:
     from langchain.text_splitter import RecursiveCharacterTextSplitter
 
+# Token-aware chunker — imported but only used when the feature flag is on.
+try:
+    from wagtail_rag.utils.chunker import paragraph_token_chunker, get_tokenizer_for_embedding
+except Exception:
+    paragraph_token_chunker = None
+    get_tokenizer_for_embedding = None
+
 logger = logging.getLogger(__name__)
 
-DEFAULT_CHUNK_SIZE = 1500
-DEFAULT_CHUNK_OVERLAP = 100
+# Defaults read from conf so settings drive behavior
+DEFAULT_CHUNK_SIZE = conf.indexing.chunk_size
+DEFAULT_CHUNK_OVERLAP = conf.indexing.chunk_overlap
 MIN_FIELD_LENGTH = 10
 
 # Fields on every Wagtail page that carry no user content.
@@ -79,14 +75,38 @@ class WagtailAPIExtractor:
         self,
         chunk_size: Optional[int] = None,
         chunk_overlap: Optional[int] = None,
+        use_token_aware_chunking: Optional[bool] = None,
     ):
-        self.chunk_size = chunk_size or conf.indexing.chunk_size
-        self.chunk_overlap = chunk_overlap or conf.indexing.chunk_overlap
+        self.chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
+        self.chunk_overlap = chunk_overlap or DEFAULT_CHUNK_OVERLAP
+
+        if use_token_aware_chunking is not None:
+            self._use_token_aware = bool(use_token_aware_chunking)
+        else:
+            self._use_token_aware = conf.indexing.use_token_aware_chunking
+
         self.text_splitter = RecursiveCharacterTextSplitter(
             chunk_size=self.chunk_size,
             chunk_overlap=self.chunk_overlap,
             length_function=len,
         )
+        self.tokenizer = None
+        if self._use_token_aware and get_tokenizer_for_embedding is not None:
+            try:
+                self.tokenizer = get_tokenizer_for_embedding(conf.embedding.model)
+            except Exception:
+                logger.warning(
+                    "Token-aware chunking requested but tokenizer init failed; "
+                    "falling back to character-based splitter."
+                )
+                self._use_token_aware = False
+
+        if self._use_token_aware and (self.tokenizer is None or paragraph_token_chunker is None):
+            logger.warning(
+                "Token-aware chunking requested but dependencies are unavailable; "
+                "falling back to character-based splitter."
+            )
+            self._use_token_aware = False
 
     # -------------------------------------------------------------------------
     # Field discovery
@@ -162,7 +182,7 @@ class WagtailAPIExtractor:
         parts = [
             self._clean_text(v.source if hasattr(v, "source") else v)
             for v in data.values()
-            if isinstance(v, str) and v.strip() or hasattr(v, "source")
+            if (isinstance(v, str) and v.strip()) or hasattr(v, "source")
         ]
         return " ".join(parts)
 
@@ -170,7 +190,7 @@ class WagtailAPIExtractor:
         parts = [
             self._clean_text(item.source if hasattr(item, "source") else item)
             for item in data
-            if isinstance(item, str) and item.strip() or hasattr(item, "source")
+            if (isinstance(item, str) and item.strip()) or hasattr(item, "source")
         ]
         return " ".join(parts)
 
@@ -183,7 +203,7 @@ class WagtailAPIExtractor:
         except Exception:
             pass
 
-        value = block.value
+        value = getattr(block, "value", None)
 
         if hasattr(value, "source"):
             return self._clean_text(value.source) or None
@@ -228,7 +248,15 @@ class WagtailAPIExtractor:
                 "block_type": block_type,
             }
 
-            chunks = self.text_splitter.split_text(block_text)
+            if self._use_token_aware:
+                chunks = list(
+                    paragraph_token_chunker(
+                        block_text, self.tokenizer, chunk_size=self.chunk_size, overlap=self.chunk_overlap
+                    )
+                )
+            else:
+                chunks = self.text_splitter.split_text(block_text)
+
             for i, chunk in enumerate(chunks):
                 documents.append(
                     Document(
@@ -273,20 +301,40 @@ class WagtailAPIExtractor:
     ) -> List[Document]:
         """Chunk a plain text / RichTextField field."""
         header = f"Page: {title}\nSection: {field_name}\n\n"
-        chunks = self.text_splitter.split_text(text)
-        return [
-            Document(
-                page_content=f"{header}{chunk}",
-                metadata={
-                    **base_metadata,
-                    "section": field_name,
-                    "chunk_index": i,
-                    "total_chunks": len(chunks),
-                    "content_length": len(chunk),
-                },
+
+        if self._use_token_aware:
+            chunks = list(
+                paragraph_token_chunker(text, self.tokenizer, chunk_size=self.chunk_size, overlap=self.chunk_overlap)
             )
-            for i, chunk in enumerate(chunks)
-        ]
+        else:
+            chunks = self.text_splitter.split_text(text)
+
+        docs = []
+        for i, chunk in enumerate(chunks):
+            meta = {
+                **base_metadata,
+                "section": field_name,
+                "chunk_index": i,
+                "total_chunks": len(chunks),
+                "content_length": len(chunk),
+                "extracted_fields": field_name,
+            }
+            if self._use_token_aware:
+                try:
+                    meta["token_count"] = len(self.tokenizer.encode(chunk, add_special_tokens=False))
+                except Exception:
+                    meta["token_count"] = None
+                meta["chunk_kind"] = "field"
+                meta["indexer_version"] = "token-aware-v2-20260508"
+
+            docs.append(
+                Document(
+                    page_content=f"{header}{chunk}",
+                    metadata=meta,
+                )
+            )
+        return docs
+
 
     # -------------------------------------------------------------------------
     # Page extraction
@@ -328,7 +376,9 @@ class WagtailAPIExtractor:
         """Extract and chunk all content fields from a Wagtail page.
 
         Always includes a title document. StreamField fields are chunked
-        per-block; other fields use RecursiveCharacterTextSplitter.
+        per-block; other fields use RecursiveCharacterTextSplitter (v1) or the
+        token-aware paragraph chunker (v2) based on the
+        ``use_token_aware_chunking`` feature flag.
         """
         candidate_fields, field_source = self._resolve_candidate_fields(page)
         base_metadata = self._build_metadata(page)
@@ -338,16 +388,26 @@ class WagtailAPIExtractor:
         documents: List[Document] = []
         extracted_fields: List[str] = []
 
+        title_meta = {
+            **base_metadata,
+            "section": "title",
+            "chunk_index": 0,
+            "total_chunks": 1,
+            "content_length": len(title),
+            "extracted_fields": "title",
+        }
+        if self._use_token_aware:
+            try:
+                title_meta["token_count"] = len(self.tokenizer.encode(title, add_special_tokens=False))
+            except Exception:
+                title_meta["token_count"] = None
+            title_meta["chunk_kind"] = "field"
+            title_meta["indexer_version"] = "token-aware-v2-20260508"
+
         documents.append(
             Document(
                 page_content=f"Page: {title}\nSection: title\n\n{title}",
-                metadata={
-                    **base_metadata,
-                    "section": "title",
-                    "chunk_index": 0,
-                    "total_chunks": 1,
-                    "content_length": len(title),
-                },
+                metadata=title_meta,
             )
         )
 
@@ -389,6 +449,16 @@ class WagtailAPIExtractor:
         return documents
 
 
-def page_to_documents_api_extractor(page) -> List[Document]:
-    """Extract LangChain Documents from a Wagtail page."""
-    return WagtailAPIExtractor().extract_page(page)
+def page_to_documents_api_extractor(
+    page, use_token_aware_chunking: Optional[bool] = None,
+) -> List[Document]:
+    """Extract LangChain Documents from a Wagtail page.
+
+    Args:
+        page: A Wagtail page instance.
+        use_token_aware_chunking: Override the feature flag. ``None`` reads from
+            ``WAGTAIL_RAG["indexing"]["use_token_aware_chunking"]``.
+    """
+    return WagtailAPIExtractor(
+        use_token_aware_chunking=use_token_aware_chunking,
+    ).extract_page(page)

--- a/wagtail_rag/content_extraction/api_fields_extractor.py
+++ b/wagtail_rag/content_extraction/api_fields_extractor.py
@@ -18,7 +18,10 @@ except ImportError:
 
 # Token-aware chunker — imported but only used when the feature flag is on.
 try:
-    from wagtail_rag.utils.chunker import paragraph_token_chunker, get_tokenizer_for_embedding
+    from wagtail_rag.utils.chunker import (
+        paragraph_token_chunker,
+        get_tokenizer_for_embedding,
+    )
 except Exception:
     paragraph_token_chunker = None
     get_tokenizer_for_embedding = None
@@ -101,7 +104,9 @@ class WagtailAPIExtractor:
                 )
                 self._use_token_aware = False
 
-        if self._use_token_aware and (self.tokenizer is None or paragraph_token_chunker is None):
+        if self._use_token_aware and (
+            self.tokenizer is None or paragraph_token_chunker is None
+        ):
             logger.warning(
                 "Token-aware chunking requested but dependencies are unavailable; "
                 "falling back to character-based splitter."
@@ -251,7 +256,10 @@ class WagtailAPIExtractor:
             if self._use_token_aware:
                 chunks = list(
                     paragraph_token_chunker(
-                        block_text, self.tokenizer, chunk_size=self.chunk_size, overlap=self.chunk_overlap
+                        block_text,
+                        self.tokenizer,
+                        chunk_size=self.chunk_size,
+                        overlap=self.chunk_overlap,
                     )
                 )
             else:
@@ -304,7 +312,12 @@ class WagtailAPIExtractor:
 
         if self._use_token_aware:
             chunks = list(
-                paragraph_token_chunker(text, self.tokenizer, chunk_size=self.chunk_size, overlap=self.chunk_overlap)
+                paragraph_token_chunker(
+                    text,
+                    self.tokenizer,
+                    chunk_size=self.chunk_size,
+                    overlap=self.chunk_overlap,
+                )
             )
         else:
             chunks = self.text_splitter.split_text(text)
@@ -321,7 +334,9 @@ class WagtailAPIExtractor:
             }
             if self._use_token_aware:
                 try:
-                    meta["token_count"] = len(self.tokenizer.encode(chunk, add_special_tokens=False))
+                    meta["token_count"] = len(
+                        self.tokenizer.encode(chunk, add_special_tokens=False)
+                    )
                 except Exception:
                     meta["token_count"] = None
                 meta["chunk_kind"] = "field"
@@ -334,7 +349,6 @@ class WagtailAPIExtractor:
                 )
             )
         return docs
-
 
     # -------------------------------------------------------------------------
     # Page extraction
@@ -398,7 +412,9 @@ class WagtailAPIExtractor:
         }
         if self._use_token_aware:
             try:
-                title_meta["token_count"] = len(self.tokenizer.encode(title, add_special_tokens=False))
+                title_meta["token_count"] = len(
+                    self.tokenizer.encode(title, add_special_tokens=False)
+                )
             except Exception:
                 title_meta["token_count"] = None
             title_meta["chunk_kind"] = "field"
@@ -450,7 +466,8 @@ class WagtailAPIExtractor:
 
 
 def page_to_documents_api_extractor(
-    page, use_token_aware_chunking: Optional[bool] = None,
+    page,
+    use_token_aware_chunking: Optional[bool] = None,
 ) -> List[Document]:
     """Extract LangChain Documents from a Wagtail page.
 

--- a/wagtail_rag/templates/wagtail_rag/chatbox.html
+++ b/wagtail_rag/templates/wagtail_rag/chatbox.html
@@ -4,6 +4,9 @@ Wagtail RAG chatbox widget — include this as a partial, not a standalone page.
 Usage in base.html (typically just before </body>):
     {% include "wagtail_rag/chatbox.html" %}
 
+Feature flag — enable the token-aware chunking implementation:
+    {% include "wagtail_rag/chatbox.html" with use_token_aware_chunking="true" %}
+
 The widget renders a floating action button (bottom-right). Clicking it opens
 the chat panel. No wrapper div or positioning needed in the host template.
 
@@ -11,7 +14,7 @@ Theming: override CSS custom properties in your site's stylesheet, e.g.:
     #rag-chatbox-root { --cb-primary: #your-brand-color; }
 {% endcomment %}
 
-<div id="rag-chatbox-root" data-api-url="{% url 'wagtail_rag:rag_chat_api' %}">
+<div id="rag-chatbox-root" data-api-url="{% url 'wagtail_rag:rag_chat_api' %}"{% if use_token_aware_chunking %} data-use-token-aware-chunking="{{ use_token_aware_chunking }}"{% endif %}>
   <style>
     /* Scoped to #rag-chatbox-root — does not affect the host page */
     #rag-chatbox-root {
@@ -386,6 +389,14 @@ Theming: override CSS custom properties in your site's stylesheet, e.g.:
     const SESSION_KEY = 'ragChatSessionId';
     const MAX_SOURCES = 3;
 
+    /* Feature flag: token-aware chunking.
+       Set data-use-token-aware-chunking="true" on #rag-chatbox-root to enable,
+       "false" to force-disable, or omit to let the server-side setting decide. */
+    const _tacAttr = (root.dataset.useTokenAwareChunking || '').toLowerCase();
+    const USE_TOKEN_AWARE_CHUNKING = _tacAttr === 'true' ? true
+                                   : _tacAttr === 'false' ? false
+                                   : null;
+
     const fab       = document.getElementById('cb-fab');
     const panel     = document.getElementById('cb-panel');
     const msgList   = document.getElementById('cb-messages');
@@ -536,13 +547,17 @@ Theming: override CSS custom properties in your site's stylesheet, e.g.:
       showTyping();
 
       try {
+        const payload = { question: q, session_id: sessionId };
+        if (USE_TOKEN_AWARE_CHUNKING !== null) {
+          payload.use_token_aware_chunking = USE_TOKEN_AWARE_CHUNKING;
+        }
         const res = await fetch(CHAT_API, {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'X-CSRFToken': getCsrfToken(),
           },
-          body: JSON.stringify({ question: q, session_id: sessionId }),
+          body: JSON.stringify(payload),
         });
 
         const data = await res.json();

--- a/wagtail_rag/tests/test_api_views.py
+++ b/wagtail_rag/tests/test_api_views.py
@@ -21,6 +21,7 @@ class TestChatAPI(TestCase):
     def test_valid_post_returns_answer(self, mock_get_chatbot):
         """Valid POST with question returns 200 and answer."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {
             "answer": "Test answer",
             "sources": [{"title": "Test Page", "url": "/test/"}],
@@ -83,6 +84,7 @@ class TestChatAPI(TestCase):
     def test_session_and_filter_forwarded(self, mock_get_chatbot):
         """session_id and valid dict filter are forwarded correctly."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -109,6 +111,7 @@ class TestChatAPI(TestCase):
     def test_llm_kwargs_sanitised(self, mock_get_chatbot):
         """Only whitelisted llm_kwargs keys are forwarded; others are stripped."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -135,6 +138,7 @@ class TestChatAPI(TestCase):
     def test_non_dict_filter_ignored(self, mock_get_chatbot):
         """A filter value that is not a dict is silently ignored (treated as no filter)."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -151,6 +155,7 @@ class TestChatAPI(TestCase):
     def test_chatbot_exception_returns_500(self, mock_get_chatbot):
         """Unhandled exception from chatbot returns 500 with generic message."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.side_effect = Exception("boom")
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -168,6 +173,7 @@ class TestChatAPI(TestCase):
     def test_get_request_accepted(self, mock_get_chatbot):
         """GET with ?q= parameter returns 200."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -189,6 +195,7 @@ class TestChatAPI(TestCase):
         from unittest.mock import patch as _patch
 
         with _patch("wagtail_rag.views.get_chatbot") as mock_gc:
+            mock_gc.return_value.use_token_aware_chunking = False
             mock_gc.return_value.query.return_value = {"answer": "ok", "sources": []}
             request = self.factory.post(
                 "/api/rag/chat/",
@@ -230,6 +237,7 @@ class TestChatAPICSRF(TestCase):
     def test_post_without_csrf_token_rejected(self, mock_get_chatbot):
         """POST without CSRF token is rejected with 403 when enforcement is active."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -246,6 +254,7 @@ class TestChatAPICSRF(TestCase):
     def test_post_with_csrf_token_accepted(self, mock_get_chatbot):
         """POST with valid CSRF token is accepted."""
         mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
         mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
         mock_get_chatbot.return_value = mock_chatbot
 
@@ -262,6 +271,104 @@ class TestChatAPICSRF(TestCase):
             HTTP_X_CSRFTOKEN=csrf_token.value,
         )
         self.assertEqual(response.status_code, 200)
+
+
+class TestFeatureFlagAPI(TestCase):
+    """Tests for use_token_aware_chunking feature flag in the API."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    @patch("wagtail_rag.views.get_chatbot")
+    def test_post_with_feature_flag_true(self, mock_get_chatbot):
+        """POST with use_token_aware_chunking=True forwards it to get_chatbot."""
+        mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = True
+        mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
+        mock_get_chatbot.return_value = mock_chatbot
+
+        request = self.factory.post(
+            "/api/rag/chat/",
+            data=json.dumps({"question": "hi", "use_token_aware_chunking": True}),
+            content_type="application/json",
+        )
+        response = rag_chat_api(request)
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertTrue(data["use_token_aware_chunking"])
+        self.assertTrue(mock_get_chatbot.call_args[1]["use_token_aware_chunking"])
+
+    @patch("wagtail_rag.views.get_chatbot")
+    def test_post_with_feature_flag_false(self, mock_get_chatbot):
+        """POST with use_token_aware_chunking=False forwards it to get_chatbot."""
+        mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
+        mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
+        mock_get_chatbot.return_value = mock_chatbot
+
+        request = self.factory.post(
+            "/api/rag/chat/",
+            data=json.dumps({"question": "hi", "use_token_aware_chunking": False}),
+            content_type="application/json",
+        )
+        response = rag_chat_api(request)
+
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.content)
+        self.assertFalse(data["use_token_aware_chunking"])
+        self.assertFalse(mock_get_chatbot.call_args[1]["use_token_aware_chunking"])
+
+    @patch("wagtail_rag.views.get_chatbot")
+    def test_post_without_feature_flag_passes_none(self, mock_get_chatbot):
+        """POST without use_token_aware_chunking passes None (server default)."""
+        mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
+        mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
+        mock_get_chatbot.return_value = mock_chatbot
+
+        request = self.factory.post(
+            "/api/rag/chat/",
+            data=json.dumps({"question": "hi"}),
+            content_type="application/json",
+        )
+        rag_chat_api(request)
+
+        self.assertIsNone(mock_get_chatbot.call_args[1]["use_token_aware_chunking"])
+
+    @patch("wagtail_rag.views.get_chatbot")
+    def test_get_with_feature_flag(self, mock_get_chatbot):
+        """GET with use_token_aware_chunking=true forwards it to get_chatbot."""
+        mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = True
+        mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
+        mock_get_chatbot.return_value = mock_chatbot
+
+        request = self.factory.get(
+            "/api/rag/chat/", {"q": "hello", "use_token_aware_chunking": "true"}
+        )
+        response = rag_chat_api(request)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(mock_get_chatbot.call_args[1]["use_token_aware_chunking"])
+
+    @patch("wagtail_rag.views.get_chatbot")
+    def test_response_includes_feature_flag(self, mock_get_chatbot):
+        """Response always includes use_token_aware_chunking in the payload."""
+        mock_chatbot = MagicMock()
+        mock_chatbot.use_token_aware_chunking = False
+        mock_chatbot.query.return_value = {"answer": "ok", "sources": []}
+        mock_get_chatbot.return_value = mock_chatbot
+
+        request = self.factory.post(
+            "/api/rag/chat/",
+            data=json.dumps({"question": "hi"}),
+            content_type="application/json",
+        )
+        response = rag_chat_api(request)
+
+        data = json.loads(response.content)
+        self.assertIn("use_token_aware_chunking", data)
 
 
 if __name__ == "__main__":

--- a/wagtail_rag/tests/test_extraction.py
+++ b/wagtail_rag/tests/test_extraction.py
@@ -236,6 +236,91 @@ class TestFeatureFlagExtractor(unittest.TestCase):
             self.assertNotIn("indexer_version", doc.metadata)
             self.assertNotIn("token_count", doc.metadata)
 
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.get_tokenizer_for_embedding"
+    )
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.paragraph_token_chunker"
+    )
+    def test_flag_true_adds_v2_metadata(self, mock_chunker, mock_tokenizer):
+        """When flag is on, plain-field documents include token-aware metadata."""
+        mock_tok = MagicMock()
+        mock_tok.encode.return_value = [1, 2, 3]
+        mock_tokenizer.return_value = mock_tok
+        mock_chunker.return_value = ["Short intro text."]
+
+        extractor = WagtailAPIExtractor(use_token_aware_chunking=True)
+
+        page = MagicMock()
+        page.id = 11
+        page.title = "Test"
+        page.slug = "test"
+        page.full_url = "https://example.com/test/"
+        page.last_published_at = None
+        page.__class__.__name__ = "TestPage"
+
+        with patch.object(
+            WagtailAPIExtractor, "_scan_search_fields", return_value=["intro"]
+        ):
+            with patch.object(
+                extractor, "_extract_field_value", return_value="Short intro text."
+            ):
+                docs = extractor.extract_page(page)
+
+        self.assertGreater(len(docs), 1)
+        for doc in docs:
+            self.assertIn("indexer_version", doc.metadata)
+            self.assertEqual(doc.metadata["indexer_version"], "token-aware-v2-20260508")
+            self.assertIn("token_count", doc.metadata)
+            self.assertEqual(doc.metadata["token_count"], 3)
+
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.get_tokenizer_for_embedding"
+    )
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.paragraph_token_chunker"
+    )
+    def test_flag_true_adds_v2_metadata_for_streamfield_chunks(
+        self, mock_chunker, mock_tokenizer
+    ):
+        """Token-aware metadata is present for each chunk emitted from StreamField content."""
+        mock_tok = MagicMock()
+        mock_tok.encode.return_value = [1, 2, 3, 4]
+        mock_tokenizer.return_value = mock_tok
+        mock_chunker.return_value = ["First block text that is long enough."]
+
+        extractor = WagtailAPIExtractor(use_token_aware_chunking=True)
+
+        page = MagicMock()
+        page.id = 12
+        page.title = "Test"
+        page.slug = "test"
+        page.full_url = "https://example.com/test/"
+        page.last_published_at = None
+        page.__class__.__name__ = "TestPage"
+
+        mock_block = MagicMock()
+        mock_block.render_as_block.return_value = "First block text that is long enough."
+        mock_block.block_type = "paragraph"
+        page.body = [mock_block]
+
+        with patch.object(
+            WagtailAPIExtractor, "_scan_search_fields", return_value=["body"]
+        ):
+            with patch.object(
+                WagtailAPIExtractor, "_is_streamfield", return_value=True
+            ):
+                docs = extractor.extract_page(page)
+
+        body_docs = [d for d in docs if d.metadata["section"] == "body"]
+        self.assertEqual(len(body_docs), 1)
+        for doc in body_docs:
+            self.assertIn("indexer_version", doc.metadata)
+            self.assertEqual(doc.metadata["indexer_version"], "token-aware-v2-20260508")
+            self.assertIn("token_count", doc.metadata)
+            self.assertEqual(doc.metadata["token_count"], 4)
+            self.assertEqual(doc.metadata["chunk_kind"], "streamfield_block")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/wagtail_rag/tests/test_extraction.py
+++ b/wagtail_rag/tests/test_extraction.py
@@ -138,11 +138,11 @@ class TestWagtailAPIExtractor(unittest.TestCase):
             ):
                 docs = extractor.extract_page(page)
 
-        # title doc + body doc
-        self.assertEqual(len(docs), 2)
+        # title doc + body doc + canonical full-page blob
+        self.assertEqual(len(docs), 3)
         for doc in docs:
             self.assertIn("Multigrain", doc.page_content)
-            self.assertIn(doc.metadata["section"], ("title", "body"))
+            self.assertIn(doc.metadata["section"], ("title", "body", "full_page"))
 
     def test_extract_page_large_field_is_split(self):
         """A field larger than chunk_size should produce multiple chunks."""
@@ -185,6 +185,52 @@ class TestWagtailAPIExtractor(unittest.TestCase):
         self.assertEqual(metadata["title"], "Test Page")
         self.assertEqual(metadata["slug"], "test-page")
         self.assertEqual(metadata["url"], "https://example.com/test/")
+
+
+class TestFeatureFlagExtractor(unittest.TestCase):
+    """Tests for use_token_aware_chunking feature flag in the extractor."""
+
+    def test_default_uses_character_splitter(self):
+        """With default settings (flag=False), token-aware chunking is off."""
+        extractor = WagtailAPIExtractor()
+        self.assertFalse(extractor._use_token_aware)
+
+    def test_explicit_false_uses_character_splitter(self):
+        """Passing use_token_aware_chunking=False disables token-aware chunking."""
+        extractor = WagtailAPIExtractor(use_token_aware_chunking=False)
+        self.assertFalse(extractor._use_token_aware)
+
+    @patch("wagtail_rag.content_extraction.api_fields_extractor.get_tokenizer_for_embedding")
+    @patch("wagtail_rag.content_extraction.api_fields_extractor.paragraph_token_chunker")
+    def test_explicit_true_enables_token_aware(self, mock_chunker, mock_tokenizer):
+        """Passing use_token_aware_chunking=True enables token-aware chunking."""
+        mock_tokenizer.return_value = MagicMock()
+        extractor = WagtailAPIExtractor(use_token_aware_chunking=True)
+        self.assertTrue(extractor._use_token_aware)
+
+    def test_flag_false_no_v2_metadata(self):
+        """When flag is off, documents do NOT contain token-aware metadata."""
+        extractor = WagtailAPIExtractor(use_token_aware_chunking=False)
+
+        page = MagicMock()
+        page.id = 10
+        page.title = "Test"
+        page.slug = "test"
+        page.full_url = "https://example.com/test/"
+        page.last_published_at = None
+        page.__class__.__name__ = "TestPage"
+
+        with patch.object(
+            WagtailAPIExtractor, "_scan_search_fields", return_value=["intro"]
+        ):
+            with patch.object(
+                extractor, "_extract_field_value", return_value="Short intro text."
+            ):
+                docs = extractor.extract_page(page)
+
+        for doc in docs:
+            self.assertNotIn("indexer_version", doc.metadata)
+            self.assertNotIn("token_count", doc.metadata)
 
 
 if __name__ == "__main__":

--- a/wagtail_rag/tests/test_extraction.py
+++ b/wagtail_rag/tests/test_extraction.py
@@ -138,11 +138,11 @@ class TestWagtailAPIExtractor(unittest.TestCase):
             ):
                 docs = extractor.extract_page(page)
 
-        # title doc + body doc + canonical full-page blob
-        self.assertEqual(len(docs), 3)
+        # title doc + body doc
+        self.assertEqual(len(docs), 2)
         for doc in docs:
             self.assertIn("Multigrain", doc.page_content)
-            self.assertIn(doc.metadata["section"], ("title", "body", "full_page"))
+            self.assertIn(doc.metadata["section"], ("title", "body"))
 
     def test_extract_page_large_field_is_split(self):
         """A field larger than chunk_size should produce multiple chunks."""

--- a/wagtail_rag/tests/test_extraction.py
+++ b/wagtail_rag/tests/test_extraction.py
@@ -200,8 +200,12 @@ class TestFeatureFlagExtractor(unittest.TestCase):
         extractor = WagtailAPIExtractor(use_token_aware_chunking=False)
         self.assertFalse(extractor._use_token_aware)
 
-    @patch("wagtail_rag.content_extraction.api_fields_extractor.get_tokenizer_for_embedding")
-    @patch("wagtail_rag.content_extraction.api_fields_extractor.paragraph_token_chunker")
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.get_tokenizer_for_embedding"
+    )
+    @patch(
+        "wagtail_rag.content_extraction.api_fields_extractor.paragraph_token_chunker"
+    )
     def test_explicit_true_enables_token_aware(self, mock_chunker, mock_tokenizer):
         """Passing use_token_aware_chunking=True enables token-aware chunking."""
         mock_tokenizer.return_value = MagicMock()

--- a/wagtail_rag/tests/test_extraction.py
+++ b/wagtail_rag/tests/test_extraction.py
@@ -300,7 +300,9 @@ class TestFeatureFlagExtractor(unittest.TestCase):
         page.__class__.__name__ = "TestPage"
 
         mock_block = MagicMock()
-        mock_block.render_as_block.return_value = "First block text that is long enough."
+        mock_block.render_as_block.return_value = (
+            "First block text that is long enough."
+        )
         mock_block.block_type = "paragraph"
         page.body = [mock_block]
 

--- a/wagtail_rag/utils/chunker.py
+++ b/wagtail_rag/utils/chunker.py
@@ -113,7 +113,7 @@ def paragraph_token_chunker(
                 # build overlap window (keep last sentences until overlap satisfied)
                 overlap_tokens = 0
                 new_window: List[str] = []
-                for sent in reversed[str](window):
+                for sent in reversed(window):
                     tlen = tokens_of(sent, tokenizer)
                     if overlap_tokens + tlen > overlap:
                         break
@@ -338,12 +338,12 @@ def page_to_chunks(
             # collect for canonical blob
             canonical_sections.append((field_name, field_text))
             # chunk field_text
-            chunks = list[str](
+            chunks = list(
                 paragraph_token_chunker(
                     field_text, tokenizer, chunk_size=chunk_size, overlap=overlap
                 )
             )
-            for i, chunk in enumerate[str](chunks):
+            for i, chunk in enumerate(chunks):
                 yield {
                     "text": f"Page: {title}\nSection: {field_name}\n\n{chunk}",
                     "metadata": {

--- a/wagtail_rag/utils/chunker.py
+++ b/wagtail_rag/utils/chunker.py
@@ -3,17 +3,21 @@ import re
 import unicodedata
 from typing import Iterable, List, Tuple, Optional, Dict, Any
 
+
 # Tokenizer loaders (try transformers, then tiktoken fallback)
 def _load_transformers_tokenizer(model_name: str):
     try:
         from transformers import AutoTokenizer
+
         return AutoTokenizer.from_pretrained(model_name)
     except Exception:
         return None
 
+
 def _load_tiktoken_encoder(model_hint: Optional[str] = None):
     try:
         import tiktoken
+
         # prefer cl100k_base for OpenAI-like models; fallback to encoding_for_model if hint provided
         try:
             return tiktoken.get_encoding("cl100k_base")
@@ -23,6 +27,7 @@ def _load_tiktoken_encoder(model_hint: Optional[str] = None):
             return None
     except Exception:
         return None
+
 
 def get_tokenizer_for_embedding(model_name: Optional[str]) -> Any:
     """
@@ -36,10 +41,13 @@ def get_tokenizer_for_embedding(model_name: Optional[str]) -> Any:
         return tok
     enc = _load_tiktoken_encoder(model_name)
     if enc:
+
         class TiktokenAdapter:
             def encode(self, text, add_special_tokens=False):
                 return enc.encode(text or "")
+
         return TiktokenAdapter()
+
     # fallback: simple whitespace-based pseudo-tokenizer
     class SimpleTokenizer:
         def encode(self, text, add_special_tokens=False):
@@ -48,13 +56,17 @@ def get_tokenizer_for_embedding(model_name: Optional[str]) -> Any:
             words = re.findall(r"\S+", text)
             # scale factor to approximate subword tokens
             return ["w"] * max(1, int(len(words) * 1.3))
+
     return SimpleTokenizer()
 
+
 # Basic sentence splitter (replaceable with spacy/nltk)
-_SENTENCE_SPLIT_RE = re.compile(r'(?<=[.!?])\s+')
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
 
 def simple_sentence_split(text: str) -> List[str]:
     return [s.strip() for s in _SENTENCE_SPLIT_RE.split(text.strip()) if s.strip()]
+
 
 def tokens_of(text: str, tokenizer) -> int:
     try:
@@ -64,6 +76,7 @@ def tokens_of(text: str, tokenizer) -> int:
         # fallback: approximate
         words = re.findall(r"\S+", text or "")
         return max(1, int(len(words) * 1.3)) if words else 0
+
 
 def paragraph_token_chunker(
     text: str,
@@ -77,7 +90,7 @@ def paragraph_token_chunker(
     """
     if not text or not text.strip():
         return
-    paragraphs = [p.strip() for p in re.split(r'\n{2,}', text) if p.strip()]
+    paragraphs = [p.strip() for p in re.split(r"\n{2,}", text) if p.strip()]
     for p in paragraphs:
         if tokens_of(p, tokenizer) <= chunk_size:
             yield p
@@ -111,6 +124,7 @@ def paragraph_token_chunker(
         if window:
             yield " ".join(window)
 
+
 # -------------------------
 # Page-level generic exporter
 # -------------------------
@@ -120,6 +134,7 @@ def _ascii_fold(text: str) -> str:
     normalized = unicodedata.normalize("NFKD", text)
     return "".join(ch for ch in normalized if not unicodedata.combining(ch))
 
+
 def _clean_html_preserve_paragraphs(value: Any) -> str:
     """
     Minimal HTML cleaning that preserves paragraph breaks for chunking.
@@ -127,6 +142,7 @@ def _clean_html_preserve_paragraphs(value: Any) -> str:
     """
     try:
         from django.utils.html import strip_tags
+
         text = str(value)
         text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
         text = re.sub(r"</p>", "\n\n", text, flags=re.IGNORECASE)
@@ -138,13 +154,16 @@ def _clean_html_preserve_paragraphs(value: Any) -> str:
         # fallback: plain string
         return " ".join(str(value).split())
 
+
 def _is_streamfield(page, field_name: str) -> bool:
     try:
         from wagtail.fields import StreamField
+
         field = page._meta.get_field(field_name)
         return isinstance(field, StreamField)
     except Exception:
         return False
+
 
 def _extract_streamfield_text(page, field_name: str) -> str:
     value = getattr(page, field_name, None)
@@ -166,12 +185,19 @@ def _extract_streamfield_text(page, field_name: str) -> str:
             parts.append(_clean_html_preserve_paragraphs(val))
         elif isinstance(val, dict):
             # collect string fields
-            parts.extend(_clean_html_preserve_paragraphs(v) for v in val.values() if isinstance(v, str))
+            parts.extend(
+                _clean_html_preserve_paragraphs(v)
+                for v in val.values()
+                if isinstance(v, str)
+            )
         elif isinstance(val, list):
-            parts.extend(_clean_html_preserve_paragraphs(i) for i in val if isinstance(i, str))
+            parts.extend(
+                _clean_html_preserve_paragraphs(i) for i in val if isinstance(i, str)
+            )
         else:
             parts.append(_clean_html_preserve_paragraphs(str(val)))
     return " ".join(p for p in parts if p)
+
 
 def _discover_text_fields(page) -> List[str]:
     """
@@ -179,12 +205,39 @@ def _discover_text_fields(page) -> List[str]:
     Returns list of field names and any *_search_text properties are prioritized.
     """
     skip_fields = {
-        "id","pk","path","depth","numchild","url_path","title","slug","draft_title",
-        "content_type","content_type_id","live","has_unpublished_changes","owner",
-        "locked","locked_at","locked_by","latest_revision","latest_revision_id",
-        "latest_revision_created_at","live_revision","first_published_at","last_published_at",
-        "go_live_at","expire_at","expired","search_description","seo_title","show_in_menus",
-        "translation_key","locale","locale_id","alias_of",
+        "id",
+        "pk",
+        "path",
+        "depth",
+        "numchild",
+        "url_path",
+        "title",
+        "slug",
+        "draft_title",
+        "content_type",
+        "content_type_id",
+        "live",
+        "has_unpublished_changes",
+        "owner",
+        "locked",
+        "locked_at",
+        "locked_by",
+        "latest_revision",
+        "latest_revision_id",
+        "latest_revision_created_at",
+        "live_revision",
+        "first_published_at",
+        "last_published_at",
+        "go_live_at",
+        "expire_at",
+        "expired",
+        "search_description",
+        "seo_title",
+        "show_in_menus",
+        "translation_key",
+        "locale",
+        "locale_id",
+        "alias_of",
     }
     fields = []
     # explicit *_search_text properties
@@ -199,7 +252,9 @@ def _discover_text_fields(page) -> List[str]:
             if isinstance(val, str) and val.strip():
                 fields.append(attr)
     # model concrete fields
-    for field in getattr(page._meta, "concrete_fields", []) + getattr(page._meta, "private_fields", []):
+    for field in getattr(page._meta, "concrete_fields", []) + getattr(
+        page._meta, "private_fields", []
+    ):
         name = getattr(field, "name", None)
         if not name or name in skip_fields:
             continue
@@ -219,6 +274,7 @@ def _discover_text_fields(page) -> List[str]:
             seen.add(f)
             out.append(f)
     return out
+
 
 def page_to_chunks(
     page,
@@ -282,7 +338,11 @@ def page_to_chunks(
             # collect for canonical blob
             canonical_sections.append((field_name, field_text))
             # chunk field_text
-            chunks = list[str](paragraph_token_chunker(field_text, tokenizer, chunk_size=chunk_size, overlap=overlap))
+            chunks = list[str](
+                paragraph_token_chunker(
+                    field_text, tokenizer, chunk_size=chunk_size, overlap=overlap
+                )
+            )
             for i, chunk in enumerate[str](chunks):
                 yield {
                     "text": f"Page: {title}\nSection: {field_name}\n\n{chunk}",

--- a/wagtail_rag/utils/chunker.py
+++ b/wagtail_rag/utils/chunker.py
@@ -1,0 +1,322 @@
+# wagtail_rag/utils/chunker.py
+import re
+import unicodedata
+from typing import Iterable, List, Tuple, Optional, Dict, Any
+
+# Tokenizer loaders (try transformers, then tiktoken fallback)
+def _load_transformers_tokenizer(model_name: str):
+    try:
+        from transformers import AutoTokenizer
+        return AutoTokenizer.from_pretrained(model_name)
+    except Exception:
+        return None
+
+def _load_tiktoken_encoder(model_hint: Optional[str] = None):
+    try:
+        import tiktoken
+        # prefer cl100k_base for OpenAI-like models; fallback to encoding_for_model if hint provided
+        try:
+            return tiktoken.get_encoding("cl100k_base")
+        except Exception:
+            if model_hint:
+                return tiktoken.encoding_for_model(model_hint)
+            return None
+    except Exception:
+        return None
+
+def get_tokenizer_for_embedding(model_name: Optional[str]) -> Any:
+    """
+    Return a tokenizer-like object with .encode(text, add_special_tokens=False)
+    or a small fallback that approximates tokens by words.
+    """
+    if not model_name:
+        model_name = "sentence-transformers/all-MiniLM-L6-v2"
+    tok = _load_transformers_tokenizer(model_name)
+    if tok:
+        return tok
+    enc = _load_tiktoken_encoder(model_name)
+    if enc:
+        class TiktokenAdapter:
+            def encode(self, text, add_special_tokens=False):
+                return enc.encode(text or "")
+        return TiktokenAdapter()
+    # fallback: simple whitespace-based pseudo-tokenizer
+    class SimpleTokenizer:
+        def encode(self, text, add_special_tokens=False):
+            if not text:
+                return []
+            words = re.findall(r"\S+", text)
+            # scale factor to approximate subword tokens
+            return ["w"] * max(1, int(len(words) * 1.3))
+    return SimpleTokenizer()
+
+# Basic sentence splitter (replaceable with spacy/nltk)
+_SENTENCE_SPLIT_RE = re.compile(r'(?<=[.!?])\s+')
+
+def simple_sentence_split(text: str) -> List[str]:
+    return [s.strip() for s in _SENTENCE_SPLIT_RE.split(text.strip()) if s.strip()]
+
+def tokens_of(text: str, tokenizer) -> int:
+    try:
+        ids = tokenizer.encode(text, add_special_tokens=False)
+        return len(ids)
+    except Exception:
+        # fallback: approximate
+        words = re.findall(r"\S+", text or "")
+        return max(1, int(len(words) * 1.3)) if words else 0
+
+def paragraph_token_chunker(
+    text: str,
+    tokenizer,
+    chunk_size: int = 800,
+    overlap: int = 128,
+) -> Iterable[str]:
+    """
+    Paragraph-first, token-aware chunker.
+    Yields chunk strings whose token length <= chunk_size (except possibly last).
+    """
+    if not text or not text.strip():
+        return
+    paragraphs = [p.strip() for p in re.split(r'\n{2,}', text) if p.strip()]
+    for p in paragraphs:
+        if tokens_of(p, tokenizer) <= chunk_size:
+            yield p
+            continue
+        # split long paragraph by sentences into token windows
+        sentences = simple_sentence_split(p)
+        window: List[str] = []
+        window_tokens = 0
+        i = 0
+        while i < len(sentences):
+            s = sentences[i]
+            s_tokens = tokens_of(s, tokenizer)
+            if window_tokens + s_tokens <= chunk_size:
+                window.append(s)
+                window_tokens += s_tokens
+                i += 1
+            else:
+                if window:
+                    yield " ".join(window)
+                # build overlap window (keep last sentences until overlap satisfied)
+                overlap_tokens = 0
+                new_window: List[str] = []
+                for sent in reversed[str](window):
+                    tlen = tokens_of(sent, tokenizer)
+                    if overlap_tokens + tlen > overlap:
+                        break
+                    new_window.insert(0, sent)
+                    overlap_tokens += tlen
+                window = new_window
+                window_tokens = sum(tokens_of(x, tokenizer) for x in window)
+        if window:
+            yield " ".join(window)
+
+# -------------------------
+# Page-level generic exporter
+# -------------------------
+def _ascii_fold(text: str) -> str:
+    if not text:
+        return ""
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in normalized if not unicodedata.combining(ch))
+
+def _clean_html_preserve_paragraphs(value: Any) -> str:
+    """
+    Minimal HTML cleaning that preserves paragraph breaks for chunking.
+    Uses Django's strip_tags if available, otherwise naive removal.
+    """
+    try:
+        from django.utils.html import strip_tags
+        text = str(value)
+        text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+        text = re.sub(r"</p>", "\n\n", text, flags=re.IGNORECASE)
+        text = re.sub(r"</li>", "\n", text, flags=re.IGNORECASE)
+        text = re.sub(r"</h[1-6]>", "\n\n", text, flags=re.IGNORECASE)
+        paragraphs = re.split(r"\n{2,}", strip_tags(text))
+        return "\n\n".join(" ".join(p.split()) for p in paragraphs if p.strip())
+    except Exception:
+        # fallback: plain string
+        return " ".join(str(value).split())
+
+def _is_streamfield(page, field_name: str) -> bool:
+    try:
+        from wagtail.fields import StreamField
+        field = page._meta.get_field(field_name)
+        return isinstance(field, StreamField)
+    except Exception:
+        return False
+
+def _extract_streamfield_text(page, field_name: str) -> str:
+    value = getattr(page, field_name, None)
+    if not value:
+        return ""
+    parts = []
+    for block in value:
+        try:
+            # prefer block.render_as_block() then block.value
+            if hasattr(block, "render_as_block"):
+                txt = block.render_as_block()
+                if txt:
+                    parts.append(_clean_html_preserve_paragraphs(txt))
+                    continue
+        except Exception:
+            pass
+        val = getattr(block, "value", block)
+        if isinstance(val, str):
+            parts.append(_clean_html_preserve_paragraphs(val))
+        elif isinstance(val, dict):
+            # collect string fields
+            parts.extend(_clean_html_preserve_paragraphs(v) for v in val.values() if isinstance(v, str))
+        elif isinstance(val, list):
+            parts.extend(_clean_html_preserve_paragraphs(i) for i in val if isinstance(i, str))
+        else:
+            parts.append(_clean_html_preserve_paragraphs(str(val)))
+    return " ".join(p for p in parts if p)
+
+def _discover_text_fields(page) -> List[str]:
+    """
+    Auto-discover candidate text fields on a Wagtail page.
+    Returns list of field names and any *_search_text properties are prioritized.
+    """
+    skip_fields = {
+        "id","pk","path","depth","numchild","url_path","title","slug","draft_title",
+        "content_type","content_type_id","live","has_unpublished_changes","owner",
+        "locked","locked_at","locked_by","latest_revision","latest_revision_id",
+        "latest_revision_created_at","live_revision","first_published_at","last_published_at",
+        "go_live_at","expire_at","expired","search_description","seo_title","show_in_menus",
+        "translation_key","locale","locale_id","alias_of",
+    }
+    fields = []
+    # explicit *_search_text properties
+    for attr in dir(page.__class__):
+        if attr.endswith("_search_text") and not attr.startswith("_"):
+            try:
+                val = getattr(page, attr)
+                if callable(val):
+                    val = val()
+            except Exception:
+                val = getattr(page, attr, None)
+            if isinstance(val, str) and val.strip():
+                fields.append(attr)
+    # model concrete fields
+    for field in getattr(page._meta, "concrete_fields", []) + getattr(page._meta, "private_fields", []):
+        name = getattr(field, "name", None)
+        if not name or name in skip_fields:
+            continue
+        if getattr(field, "is_relation", False):
+            continue
+        try:
+            internal_type = field.get_internal_type()
+        except Exception:
+            internal_type = field.__class__.__name__
+        if internal_type in {"CharField", "TextField", "RichTextField", "StreamField"}:
+            fields.append(name)
+    # dedupe preserving order
+    seen = set()
+    out = []
+    for f in fields:
+        if f not in seen:
+            seen.add(f)
+            out.append(f)
+    return out
+
+def page_to_chunks(
+    page,
+    tokenizer,
+    chunk_size: int = 800,
+    overlap: int = 128,
+    emit_full_blob: bool = True,
+) -> Iterable[Dict[str, Any]]:
+    """
+    Generic exporter: yields dicts with keys:
+      - text: chunk text (string)
+      - metadata: dict with page_id, page_type, title, section, chunk_index, total_chunks, content_length, url
+    """
+    title = getattr(page, "title", "") or ""
+    page_id = getattr(page, "id", None)
+    page_type = page.__class__.__name__
+    url = None
+    for attr in ("full_url", "url"):
+        try:
+            url = getattr(page, attr)
+            break
+        except Exception:
+            url = None
+    if not url:
+        url = f"/page/{page_id}/"
+
+    candidate_fields = _discover_text_fields(page)
+    # always include title as first small chunk
+    canonical_sections: List[Tuple[str, str]] = [("title", title)]
+    # yield title doc
+    yield {
+        "text": f"Page: {title}\nSection: title\n\n{title}",
+        "metadata": {
+            "page_id": page_id,
+            "page_type": page_type,
+            "title": title,
+            "url": url,
+            "section": "title",
+            "chunk_kind": "field",
+            "chunk_index": 0,
+            "total_chunks": 1,
+            "content_length": len(title),
+        },
+    }
+
+    for field_name in candidate_fields:
+        try:
+            if _is_streamfield(page, field_name):
+                field_text = _extract_streamfield_text(page, field_name)
+            else:
+                raw = getattr(page, field_name, None)
+                if raw is None:
+                    continue
+                # prefer .source for rich text-like objects
+                if hasattr(raw, "source"):
+                    field_text = _clean_html_preserve_paragraphs(raw.source)
+                else:
+                    field_text = _clean_html_preserve_paragraphs(raw)
+            if not field_text or not field_text.strip():
+                continue
+            # collect for canonical blob
+            canonical_sections.append((field_name, field_text))
+            # chunk field_text
+            chunks = list[str](paragraph_token_chunker(field_text, tokenizer, chunk_size=chunk_size, overlap=overlap))
+            for i, chunk in enumerate[str](chunks):
+                yield {
+                    "text": f"Page: {title}\nSection: {field_name}\n\n{chunk}",
+                    "metadata": {
+                        "page_id": page_id,
+                        "page_type": page_type,
+                        "title": title,
+                        "url": url,
+                        "section": field_name,
+                        "chunk_kind": "field",
+                        "chunk_index": i,
+                        "total_chunks": len(chunks),
+                        "content_length": len(chunk),
+                    },
+                }
+        except Exception:
+            # skip problematic fields but continue
+            continue
+
+    # canonical full blob
+    if emit_full_blob and canonical_sections:
+        body = "\n\n".join(f"[{n}]\n{t}" for n, t in canonical_sections if t)
+        if body.strip():
+            yield {
+                "text": f"Page: {title}\nSection: full_page\n\n{body}",
+                "metadata": {
+                    "page_id": page_id,
+                    "page_type": page_type,
+                    "title": title,
+                    "url": url,
+                    "section": "full_page",
+                    "chunk_kind": "canonical_full_blob",
+                    "chunk_index": 0,
+                    "total_chunks": 1,
+                    "content_length": len(body),
+                },
+            }

--- a/wagtail_rag/views.py
+++ b/wagtail_rag/views.py
@@ -97,8 +97,8 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
     Protect this endpoint at the network level (auth, rate limiting) if it is
     publicly exposed.
 
-    GET  ?q=<question>[&session_id=<id>][&filter=<json>][&search_only=true]
-    POST {"question": "...", "session_id": "...", "filter": {}, "llm_kwargs": {}, "search_only": false}
+    GET  ?q=<question>[&session_id=<id>][&filter=<json>][&search_only=true][&use_token_aware_chunking=true]
+    POST {"question": "...", "session_id": "...", "filter": {}, "llm_kwargs": {}, "search_only": false, "use_token_aware_chunking": null}
 
     Response 200: {"answer": "...", "sources": [...], "session_id": "..."}
     Response 400: {"error": "..."}
@@ -131,6 +131,12 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
                 "yes",
             )
             llm_kwargs: dict = {}
+
+            _tac_raw = (request.GET.get("use_token_aware_chunking") or "").lower()
+            use_token_aware_chunking: Optional[bool] = (
+                True if _tac_raw in ("true", "1", "yes")
+                else (False if _tac_raw in ("false", "0", "no") else None)
+            )
 
             filter_str = request.GET.get("filter", "")
             metadata_filter: Optional[dict] = None
@@ -175,6 +181,10 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
             search_only = bool(data.get("search_only", False))
             metadata_filter = _validate_metadata_filter(data.get("filter"))
             llm_kwargs = _sanitize_llm_kwargs(data.get("llm_kwargs"))
+            _tac_val = data.get("use_token_aware_chunking")
+            use_token_aware_chunking = (
+                bool(_tac_val) if _tac_val is not None else None
+            )
 
         # ── validate question ─────────────────────────────────────────
         if not question:
@@ -214,11 +224,14 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
         chatbot = get_chatbot(
             metadata_filter=metadata_filter,
             llm_kwargs=llm_kwargs if llm_kwargs else {},
+            use_token_aware_chunking=use_token_aware_chunking,
         )
         result = chatbot.query(question, session_id=session_id, search_only=search_only)
 
         if use_history and session_id:
             result["session_id"] = session_id
+
+        result["use_token_aware_chunking"] = chatbot.use_token_aware_chunking
 
         return JsonResponse(result)
 

--- a/wagtail_rag/views.py
+++ b/wagtail_rag/views.py
@@ -192,7 +192,8 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
             elif isinstance(_tac_val, str):
                 _tac_lower = _tac_val.lower()
                 use_token_aware_chunking = (
-                    True if _tac_lower in ("true", "1", "yes")
+                    True
+                    if _tac_lower in ("true", "1", "yes")
                     else (False if _tac_lower in ("false", "0", "no") else None)
                 )
             else:

--- a/wagtail_rag/views.py
+++ b/wagtail_rag/views.py
@@ -134,7 +134,8 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
 
             _tac_raw = (request.GET.get("use_token_aware_chunking") or "").lower()
             use_token_aware_chunking: Optional[bool] = (
-                True if _tac_raw in ("true", "1", "yes")
+                True
+                if _tac_raw in ("true", "1", "yes")
                 else (False if _tac_raw in ("false", "0", "no") else None)
             )
 
@@ -182,9 +183,7 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
             metadata_filter = _validate_metadata_filter(data.get("filter"))
             llm_kwargs = _sanitize_llm_kwargs(data.get("llm_kwargs"))
             _tac_val = data.get("use_token_aware_chunking")
-            use_token_aware_chunking = (
-                bool(_tac_val) if _tac_val is not None else None
-            )
+            use_token_aware_chunking = bool(_tac_val) if _tac_val is not None else None
 
         # ── validate question ─────────────────────────────────────────
         if not question:

--- a/wagtail_rag/views.py
+++ b/wagtail_rag/views.py
@@ -183,7 +183,20 @@ def rag_chat_api(request: HttpRequest) -> JsonResponse:
             metadata_filter = _validate_metadata_filter(data.get("filter"))
             llm_kwargs = _sanitize_llm_kwargs(data.get("llm_kwargs"))
             _tac_val = data.get("use_token_aware_chunking")
-            use_token_aware_chunking = bool(_tac_val) if _tac_val is not None else None
+            if _tac_val is None:
+                use_token_aware_chunking = None
+            elif isinstance(_tac_val, bool):
+                use_token_aware_chunking = _tac_val
+            elif isinstance(_tac_val, (int, float)):
+                use_token_aware_chunking = bool(_tac_val)
+            elif isinstance(_tac_val, str):
+                _tac_lower = _tac_val.lower()
+                use_token_aware_chunking = (
+                    True if _tac_lower in ("true", "1", "yes")
+                    else (False if _tac_lower in ("false", "0", "no") else None)
+                )
+            else:
+                use_token_aware_chunking = None
 
         # ── validate question ─────────────────────────────────────────
         if not question:


### PR DESCRIPTION
This PR introduces a token‑based chunking implementation for Wagtail RAG indexing. The goal is to improve retrieval accuracy by aligning text chunks with actual model tokens rather than arbitrary character counts.

**Key changes:**

Added a Django settings flag to enable or disable token‑aware chunking:

```
WAGTAIL_RAG = {
    "indexing": {
        "use_token_aware_chunking": True,  # or False
    },
}
```
Provided a flat fallback key for simpler configuration:

`WAGTAIL_RAG_USE_TOKEN_AWARE_CHUNKING = True`

Updated the extractor to compute token_count metadata for each chunk, ensuring provenance and easier debugging.

Added indexer_version sentinel to metadata for future verification of .pkl files.